### PR TITLE
Explicitly define requestId

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -147,9 +147,9 @@ class LoggerPlugin {
       if (!this.logs.length) {
         return true;
       }
-      const { jwtAccess, signedRequest, response, url } = await this
-        .fileUploadMetaPromise;
-      debuglog(`Signer response: ${response}`);
+      const requestData = await this.fileUploadMetaPromise;
+      const { jwtAccess, signedRequest, url } = requestData;
+      debuglog(`Signer response: ${JSON.stringify(requestData)}`);
       if (signedRequest) {
         debuglog(`Signed request received for ${url}`);
         await request({
@@ -164,7 +164,7 @@ class LoggerPlugin {
         }
         this.uploads.push(jwtAccess);
       } else {
-        debuglog(`Bad signer response: ${response}`);
+        debuglog(`Bad signer response: ${JSON.stringify(requestData)}`);
       }
     } catch (err) {
       debuglog(err);

--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,10 @@ class LoggerPlugin {
     return coreUtil.getFileUploadMeta({
       timestamp: startTimestamp,
       auth: this.invocationInstance.config.clientId,
-      extension: '.log'
+      extension: '.log',
+      requestId:
+        this.invocationInstance.context &&
+        this.invocationInstance.context.awsRequestId
     });
   }
 


### PR DESCRIPTION
It appears in some combinations, the requestId definition in the coreUtil is somehow not set/available/defined. Explicitly put it in the kwargs.